### PR TITLE
feat: add crud operations and (temporary) apis implementation

### DIFF
--- a/src/apis/api.py
+++ b/src/apis/api.py
@@ -4,4 +4,4 @@ from src.apis.v1 import endpoints
 
 
 api_router = APIRouter()
-api_router.include_router(endpoints.router, include_in_schema=False)
+api_router.include_router(endpoints.router)

--- a/src/db/crud/flight.py
+++ b/src/db/crud/flight.py
@@ -1,3 +1,5 @@
+from itertools import groupby
+
 from sqlalchemy.orm import Session
 
 from src.db.models.flight import Flight
@@ -6,12 +8,36 @@ from src.entities.flight import FlightShow
 
 
 def post_flight_data(
-        params: Parameter,
-        flight_data: FlightShow,
-        db: Session
+    params: Parameter,
+    flight_data: FlightShow,
+    db: Session
 ):
     flight = Flight(parameters=params, **flight_data.model_dump())
     db.add(flight)
     db.commit()
     db.refresh(flight)
     return flight
+
+
+def get_all_flights_data(db: Session):
+    all_flights = db.query(Flight).all()
+    all_flights.sort(key=lambda flight: flight.parameters_id)
+    grouped_flights = {
+        id: list(group) for id, group in groupby(
+            all_flights, key=lambda flight: flight.parameters_id
+        )
+    }
+    return grouped_flights
+
+
+def get_flight_data_by_id(id: int, db: Session):
+    return db.query(Flight).filter(Flight.parameters_id == id)
+
+
+def delete_flight_data_by_id(id: int, db: Session):
+    flights_in_db = db.query(Flight).filter(Flight.parameters_id == id)
+    if not flights_in_db:
+        return {"error": f"Could not find flights having parameters_id {id}."}
+    flights_in_db.delete()
+    db.commit()
+    return {"msg": f"Deleted flights having parameters_id {id}."}

--- a/src/db/crud/parameter.py
+++ b/src/db/crud/parameter.py
@@ -10,3 +10,12 @@ def create_params(flight: FlightCreate, db: Session):
     db.commit()
     db.refresh(params)
     return params
+
+
+def delete_params_by_id(id: int, db: Session):
+    param_in_db = db.query(Parameter).filter(Parameter.id == id)
+    if not param_in_db.first():
+        return {"error": f"Could not find parameters with id {id}."}
+    param_in_db.delete()
+    db.commit()
+    return {"msg": f"Deleted parameters with id {id}."}

--- a/src/db/models/flight.py
+++ b/src/db/models/flight.py
@@ -13,7 +13,12 @@ class Flight(Base, TableNameMixin):
         ForeignKey("parameters.id", ondelete="CASCADE"),
         nullable=False
     )
-    parameters = relationship("Parameter", foreign_keys=[parameters_id])
+    parameters = relationship(
+        "Parameter",
+        foreign_keys=[parameters_id],
+        back_populates="flights",
+        cascade="all",
+    )
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     is_two_way_trip: Mapped[bool] = mapped_column(Boolean, nullable=False)
     departure_location: Mapped[str] = mapped_column(String, nullable=False)

--- a/src/db/models/parameter.py
+++ b/src/db/models/parameter.py
@@ -2,7 +2,7 @@ from datetime import date
 from typing import Optional
 
 from sqlalchemy import Boolean, Date, Integer, String
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.db.base_class import Base, TableNameMixin
 
@@ -24,4 +24,9 @@ class Parameter(Base, TableNameMixin):
     departure_date_comeback: Mapped[Optional[date]] = mapped_column(
         Date,
         nullable=True,
+    )
+    flights = relationship(
+        "Flight",
+        back_populates="parameters",
+        cascade="all, delete-orphan"
     )

--- a/src/entities/flight.py
+++ b/src/entities/flight.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
 from datetime import date, datetime
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 
 class FlightBase(BaseModel):
@@ -19,23 +19,25 @@ class FlightCreate(FlightBase):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_two_way_trip_attributes(cls, v: dict[str, Any]):
-        if v["is_two_way_trip"]:
-            assert v["departure_location_comeback"] is not None
-            assert v["arrival_location_comeback"] is not None
-            assert v["departure_date_comeback"] is not None
+    def validate_two_way_trip_attributes(cls, v: Any):
+        if v.is_two_way_trip:
+            assert v.departure_location_comeback is not None
+            assert v.arrival_location_comeback is not None
+            assert v.departure_date_comeback is not None
         return v
 
     @model_validator(mode="before")
     @classmethod
-    def validate_input_dates(cls, v: dict[str, Any]):
-        assert v["departure_date"] >= date.today()
-        if "departure_date_comeback" in v and v["departure_date_comeback"] is not None:
-            assert v["departure_date"] < v["departure_date_comeback"]
+    def validate_input_dates(cls, v: Any):
+        assert v.departure_date >= date.today()
+        if v.departure_date_comeback is not None:
+            assert v.departure_date < v.departure_date_comeback
         return v
 
 
 class FlightShow(FlightBase):
+    # model_config = ConfigDict(from_attributes=True)
+
     arrival_date: datetime
     arrival_date_comeback: Optional[datetime] = None
     airline: str
@@ -51,8 +53,8 @@ class FlightShow(FlightBase):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_arrival_dates(cls, v: dict[str, Any]):
-        assert v["departure_date"] < v["arrival_date"]
-        if "departure_date_comeback" in v and v["departure_date_comeback"] is not None:
-            assert v["departure_date_comeback"] < v["arrival_date_comeback"]
+    def validate_arrival_dates(cls, v: Any):
+        assert v.departure_date < v.arrival_date
+        if v.departure_date_comeback is not None:
+            assert v.departure_date_comeback < v.arrival_date_comeback
         return v

--- a/src/entities/flight.py
+++ b/src/entities/flight.py
@@ -1,7 +1,7 @@
 from typing import Any, Optional
 
 from datetime import date, datetime
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, model_validator
 
 
 class FlightBase(BaseModel):
@@ -36,7 +36,6 @@ class FlightCreate(FlightBase):
 
 
 class FlightShow(FlightBase):
-    # model_config = ConfigDict(from_attributes=True)
 
     arrival_date: datetime
     arrival_date_comeback: Optional[datetime] = None


### PR DESCRIPTION
Summary:

- 51bd460c3ea5c11efb0b3b4a443b3cd101c61e32:
    - add implementation of CRUD operations for both `Flight` and `Parameter` entities
    - add (temporary) apis implementation; they still do not render jinja templates and, as such, they will be modified later
    - fix `pydantic` model validators; being `BeforeValidator`(s) they have to handle `sqlalchemy` raw `Flight` objects rather than `json` objects
    - specify `cascade` options for deletion; still, the deletion of `parameters` records triggered by the deletion of `flights` records is "manually" handled. Need to explore options for handling everything automatically (i.e. without explicitly calling `delete_params_by_id`)
- b8f84b5b9e7ee1e27ef566852ad6288925bfd702:
    - remove unnecessary `ConfigDict`