### PR TITLE
fix: bugfix (pydantic validators)

### DIFF
--- a/src/entities/flight.py
+++ b/src/entities/flight.py
@@ -20,18 +20,29 @@ class FlightCreate(FlightBase):
     @model_validator(mode="before")
     @classmethod
     def validate_two_way_trip_attributes(cls, v: Any):
-        if v.is_two_way_trip:
-            assert v.departure_location_comeback is not None
-            assert v.arrival_location_comeback is not None
-            assert v.departure_date_comeback is not None
+        if isinstance(v, dict):
+            if v["is_two_way_trip"]:
+                assert v["departure_location_comeback"] is not None
+                assert v["arrival_location_comeback"] is not None
+                assert v["departure_date_comeback"] is not None
+        else:
+            if v.is_two_way_trip:
+                assert v.departure_location_comeback is not None
+                assert v.arrival_location_comeback is not None
+                assert v.departure_date_comeback is not None
         return v
 
     @model_validator(mode="before")
     @classmethod
     def validate_input_dates(cls, v: Any):
-        assert v.departure_date >= date.today()
-        if v.departure_date_comeback is not None:
-            assert v.departure_date < v.departure_date_comeback
+        if isinstance(v, dict):
+            assert v["departure_date"] >= date.today()
+            if "departure_date_comeback" in v and v["departure_date_comeback"] is not None:
+                assert v["departure_date"] < v["departure_date_comeback"]
+        else:
+            assert v.departure_date >= date.today()
+            if v.departure_date_comeback is not None:
+                assert v.departure_date < v.departure_date_comeback
         return v
 
 
@@ -52,7 +63,12 @@ class FlightShow(FlightBase):
     @model_validator(mode="before")
     @classmethod
     def validate_arrival_dates(cls, v: Any):
-        assert v.departure_date < v.arrival_date
-        if v.departure_date_comeback is not None:
-            assert v.departure_date_comeback < v.arrival_date_comeback
+        if isinstance(v, dict):
+            assert v["departure_date"] < v["arrival_date"]
+            if "departure_date_comeback" in v and v["departure_date_comeback"] is not None:
+                assert v["departure_date_comeback"] < v["arrival_date_comeback"]
+        else:
+            assert v.departure_date < v.arrival_date
+            if v.departure_date_comeback is not None:
+                assert v.departure_date_comeback < v.arrival_date_comeback
         return v


### PR DESCRIPTION
Summary:

- 7aced2dc4cf1cd8eb5a411fc3719db2388e61a31:
    - fix bug occurring while validating data: getting `dict`(s) as inputs to both `FlightCreate` and `FlightShow` in the interaction with the `POST` endpoint, getting `sqlalchemy` `Flight` objects as inputs to `FlightShow` in the interaction with the `GET` endpoints; inelegant solution to say the least, need to explore other ways of dealing with it