### PR TITLE
fix: add option to avoid ElementClickInterceptedException in headless mode

### DIFF
--- a/src/core/scraper/scraper.py
+++ b/src/core/scraper/scraper.py
@@ -29,6 +29,7 @@ class EdreamsScraper:
     def __init__(self):
         self._options = Options()
         self._options.add_argument("--headless")
+        self._options.add_argument("--window-size=1400,600")
         self._options.add_argument("user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3")
         self._options.add_experimental_option("excludeSwitches", ["enable-logging"])
         self._options.add_experimental_option("detach", True)


### PR DESCRIPTION
Summary:
- 6330ca8f10e54fc6c224deacb6880509658db7d7:
    - add option to avoid `selenium.common.exceptions.ElementClickInterceptedException` in `--headless` mode (https://stackoverflow.com/questions/62260511/org-openqa-selenium-elementclickinterceptedexception-element-click-intercepted); still, the doubt expressed in https://github.com/AlessandroMiola/flights-scraper-web-app/pull/9 pops up

